### PR TITLE
Support http proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,16 @@ Route::get('/', function() {
 });
 ```
 
+## Proxy
+
+If you need http proxy, please create a config file `goutte.php` inside config directory
+
+```php
+<?php
+
+return [
+    'http_proxy' => env('HTTP_PROXY'),
+];
+```
+
 *TIP:* If you retrieve a "Class 'Goutte' not found"-Exception try to update the autoloader by running `composer dump-autoload` in your project root.

--- a/src/GoutteServiceProvider.php
+++ b/src/GoutteServiceProvider.php
@@ -35,7 +35,13 @@ class GoutteServiceProvider extends ServiceProvider
     protected function registerGoutte()
     {
         $this->app->singleton('goutte', function ($app) {
-            return new \Goutte\Client();
+            $goutte = new \Goutte\Client();
+            if (config('goutte.http_proxy')) {
+                $client = new \GuzzleHttp\Client(['proxy' => config('goutte.http_proxy')]);
+                $goutte->setClient($client);
+            }
+
+            return $goutte;
         });
     }
 


### PR DESCRIPTION
Just added feature supporting http proxy

add HTTP_PROXY inside .env

    HTTP_PROXY=http://proxyhost:port

add config file `goutte.php`

```php
<?php

return [
    'http_proxy' => env('HTTP_PROXY'),
];
```
