### PR TITLE
Updated illuminate/support to 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.*",
+        "illuminate/support": "^6.0",
         "fabpot/goutte": "^3.2"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel v6 was released today. I've made a pull request to update the `illuminate/support` dependency for the new 6.0 version.